### PR TITLE
Ensure missing targets which depend on MightNotUpdate targets are created

### DIFF
--- a/src/make1.c
+++ b/src/make1.c
@@ -340,7 +340,9 @@ make1b( TARGET *t )
 #ifdef OPT_BUILTIN_NEEDS_EXT
 	    /* Only test a target's MightNotUpdate flag if the target's build was successful. */
 	    if( c->target->status == EXEC_CMD_OK ) {
-		if ( c->target->flags & T_FLAG_MIGHTNOTUPDATE ) {
+		/* Skip checking MightNotUpdate children if the target is bound to a missing file, */
+		/* as in this case it should be built anyway */
+		if ( c->target->flags & T_FLAG_MIGHTNOTUPDATE && t->binding != T_BIND_MISSING ) {
 		    time_t timestamp;
 
 		    /* Mark that we've seen a MightNotUpdate flag in this set of children. */


### PR DESCRIPTION
I think this commit should solve the issue which I opened regarding the MightNotUpdate dependencies causing their parents to not be updated.  It feels more like a work-around than a fix though.  Can you see any issues with it or a better way to do this?

Currently the complicated checks in the case for MightNotUpdate children end up
forcing the parent to a stable fate when the child has not updated, even when
the parent is bound to a missing file.

This work-around avoids the special handling for MightNotUpdate children when
the parent is bound to a missing file.
