### PR TITLE
Make JamPlus build correctly for linux64

### DIFF
--- a/bin/modules/c-compilers/c-gcc.jam
+++ b/bin/modules/c-compilers/c-gcc.jam
@@ -69,7 +69,7 @@ actions updated together piecemeal C.Archive
 
 actions C.Link
 {
-	"$(C.LINK)" $(LINKFLAGS) -o $(<[1]:C) $(>:C) $(NEEDLIBS:TC) $(LINKLIBS:T)
+	"$(C.LINK)" -o $(<[1]:C) $(>:C) $(NEEDLIBS:TC) $(LINKLIBS:T) $(LINKFLAGS)
 }
 
 actions together C.Ranlib

--- a/bin/modules/c-compilers/c-vc.jam
+++ b/bin/modules/c-compilers/c-vc.jam
@@ -107,7 +107,7 @@ actions response C.Link
 {
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:T) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
 }
 
 } else {
@@ -116,7 +116,7 @@ actions response C.Link
 {
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:T) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
 }
 
 actions response C.DebugLinkWithManifest
@@ -124,18 +124,18 @@ actions response C.DebugLinkWithManifest
 	REM http://msdn.microsoft.com/en-us/library/ms235591%28VS.80%29.aspx
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:T) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
 	if exist $(MANIFEST).intermediate.manifest "$(C.MT:\\)" -nologo -notify_update -manifest $(MANIFEST).intermediate.manifest -out:$(MANIFEST).embed.manifest &
 	if "%ERRORLEVEL%" == "1090650113" echo $(MANIFEST_TYPE) 24 "$(MANIFEST).embed.manifest" > "$(MANIFEST).embed.rc" &
 	"$(C.RC:\\)" $(C.RC-NOLOGO) /fo $(MANIFEST).embed.res $(MANIFEST).embed.rc &
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:TC) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
 }
 
 actions response C.LinkWithManifest
 {
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:TC) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
 	"$(C.MT:\\)" -nologo -manifest $(MANIFEST).intermediate.manifest -outputresource:$(<[1]);$(MANIFEST_TYPE)
 }
 

--- a/bin/modules/c-compilers/c-vc.jam
+++ b/bin/modules/c-compilers/c-vc.jam
@@ -75,7 +75,7 @@ rule C._RuntimeTypeHelper
 
 actions response C.ManifestToRC
 {
-	^^($(1)|$(CONTENTS)) ;
+	^^($(1:C)|$(CONTENTS)) ;
 }
 
 rule C._ManifestHelper TARGET : MANIFEST : MANIFEST_TYPE
@@ -107,7 +107,7 @@ actions response C.Link
 {
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>:C) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1]:C)
 }
 
 } else {
@@ -116,7 +116,7 @@ actions response C.Link
 {
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>:C) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1]:C)
 }
 
 actions response C.DebugLinkWithManifest
@@ -124,19 +124,19 @@ actions response C.DebugLinkWithManifest
 	REM http://msdn.microsoft.com/en-us/library/ms235591%28VS.80%29.aspx
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>:C) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1]:C)
 	if exist $(MANIFEST).intermediate.manifest "$(C.MT:\\)" -nologo -notify_update -manifest $(MANIFEST).intermediate.manifest -out:$(MANIFEST).embed.manifest &
 	if "%ERRORLEVEL%" == "1090650113" echo $(MANIFEST_TYPE) 24 "$(MANIFEST).embed.manifest" > "$(MANIFEST).embed.rc" &
 	"$(C.RC:\\)" $(C.RC-NOLOGO) /fo $(MANIFEST).embed.res $(MANIFEST).embed.rc &
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>:C) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1]:C)
 }
 
 actions response C.LinkWithManifest
 {
 	set PATH=$(MSVCBIN);$(MSVCNT_BIN_PATH:J=;);$(LINK_PATHS:E);%PATH%
 	SET INCLUDE=$(C.STDHDRS:\\J=;)
-	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1])
-	"$(C.MT:\\)" -nologo -manifest $(MANIFEST).intermediate.manifest -outputresource:$(<[1]);$(MANIFEST_TYPE)
+	"$(C.LINK:\\)" /nologo @@($(LINKFLAGS) $(>:C) $(NEEDLIBS:CT) $(LINKLIBS:CT)) /out:$(<[1]:C)
+	"$(C.MT:\\)" -nologo -manifest $(MANIFEST).intermediate.manifest -outputresource:$(<[1]:C);$(MANIFEST_TYPE)
 }
 
 }

--- a/bin/modules/c-compilers/linux64-autodetect.jam
+++ b/bin/modules/c-compilers/linux64-autodetect.jam
@@ -1,0 +1,4 @@
+IncludeModule c-compilers/c-gcc-autodetect ;
+if [ C.AutoDetect ] {
+	return ;
+}

--- a/bin/modules/c-compilers/linux64-gcc-debug.jam
+++ b/bin/modules/c-compilers/linux64-gcc-debug.jam
@@ -1,0 +1,4 @@
+C.Flags CC	: * : -g -O0 : debug : linux64 ;
+C.Flags C++	: *	: -g -O0 : debug : linux64 ;
+C.Flags M	: *	: -g -O0 : debug : linux64 ;
+C.Flags MM	: *	: -g -O0 : debug : linux64 ;

--- a/bin/modules/c-compilers/linux64-gcc-release.jam
+++ b/bin/modules/c-compilers/linux64-gcc-release.jam
@@ -1,0 +1,4 @@
+C.Flags CC	: * : -O2 : release : linux64 ;
+C.Flags C++	: *	: -O2 : release : linux64 ;
+C.Flags M	: *	: -O2 : release : linux64 ;
+C.Flags MM	: *	: -O2 : release : linux64 ;

--- a/bin/modules/c-compilers/linux64-gcc-releaseltcg.jam
+++ b/bin/modules/c-compilers/linux64-gcc-releaseltcg.jam
@@ -1,0 +1,4 @@
+C.Flags CC	: * : -O3 : releaseltcg : linux64 ;
+C.Flags C++	: *	: -O3 : releaseltcg : linux64 ;
+C.Flags M	: *	: -O3 : releaseltcg : linux64 ;
+C.Flags MM	: *	: -O3 : releaseltcg : linux64 ;

--- a/bin/modules/c-compilers/linux64-gcc.jam
+++ b/bin/modules/c-compilers/linux64-gcc.jam
@@ -1,0 +1,11 @@
+C.AR			?= ar ru ;
+C.CC			?= gcc ;
+C.C++			?= g++ ;
+C.LINK		?= g++ ;
+C.RANLIB		?= ranlib ;
+
+SUFMODULE	= .so ;
+
+C.Flags CC      : * : -m64 : * : linux64 ;
+C.Flags C++     : * : -m64 : * : linux64 ;
+C.LinkFlags   * : -m64 : * : linux64 ;

--- a/bin/scripts/DumpJamTargetInfo.jam
+++ b/bin/scripts/DumpJamTargetInfo.jam
@@ -232,6 +232,7 @@ $(solutionInfo).RelativePath = '$(SUBDIR_DOWN:E=.:J=/)'
 
 rule WriteTargetInfoFile FILENAME
 {
+	Depends all : $(FILENAME) ;
 	Always $(FILENAME) ;
 	WriteTargetInfoFileHelper $(FILENAME) ;
 }

--- a/bin/scripts/ide/xcode.lua
+++ b/bin/scripts/ide/xcode.lua
@@ -253,8 +253,8 @@ local function XcodeHelper_WritePBXLegacyTarget(self, info, allTargets, projects
 			table.insert(self.Contents, '/* Begin PBXLegacyTarget section */\n')
 		end
 
-		for curProject in ivalues(allTargets) do
-			if curProject.XcodeProjectType ~= projectType then continue end
+		for curProject in ivalues(allTargets) do repeat
+			if curProject.XcodeProjectType ~= projectType then break end
 
 			local subProjectInfo = XcodeHelper_GetProjectExportInfo(curProject.Name)
 			local subProject = Projects[curProject.Name]
@@ -304,7 +304,7 @@ local function XcodeHelper_WritePBXLegacyTarget(self, info, allTargets, projects
 			end
 
 			table.insert(self.Contents, '\t\t};\n')
-		end
+		until true end
 		if projectType == 'native' then
 			table.insert(self.Contents, '/* End PBXNativeTarget section */\n\n')
 		elseif projectType == 'legacy' then
@@ -313,8 +313,8 @@ local function XcodeHelper_WritePBXLegacyTarget(self, info, allTargets, projects
 	end
 
 	table.insert(self.Contents, "/* Begin PBXShellScriptBuildPhase section */\n")
-	for curProject in ivalues(allTargets) do
-		if curProject.XcodeProjectType ~= 'native' then continue end
+	for curProject in ivalues(allTargets) do repeat
+		if curProject.XcodeProjectType ~= 'native' then break end
 
 		local subProjectInfo = XcodeHelper_GetProjectExportInfo(curProject.Name)
 		local subProject = Projects[curProject.Name]
@@ -337,7 +337,7 @@ local function XcodeHelper_WritePBXLegacyTarget(self, info, allTargets, projects
 			table.insert(self.Contents, os.path.combine(projectsPath, 'xcodejam') .. [[ $PLATFORM $CONFIG $ACTION $TARGET_NAME";]] .. '\n')
 		end
 		table.insert(self.Contents, "\t\t};\n")
-	end
+	until true end
 	table.insert(self.Contents, expand("/* End PBXShellScriptBuildPhase section */\n\n"))
 end
 


### PR DESCRIPTION
Hi,

I just cloned the latest version of JamPlus and it wouldn't build for me for linux64 (i.e. make linux64). It seemed like there were a few files missing, and I also had a problem the -ldl linker flag was specified at the start of the commandline, whereas g++ seemed to want it at the end of the commandline.

I hope these changes might be of some use to you.
