### PR TITLE
Set build settings deployment target for iOS (iPhone/iPad) and OSX (32/6...

### DIFF
--- a/bin/modules/c-compilers/macosx.jam
+++ b/bin/modules/c-compilers/macosx.jam
@@ -266,23 +266,23 @@ rule C.MinimumOSVersion TARGET : SDK_VERSION_MIN {
 	local flags ;
 	switch $(SDK_PLATFORM) {
 		case macosx :
-			# 10.4, 10.5, 10.6, 10.7, 10.8
+			# 10.4, 10.5, 10.6, 10.7, 10.8 10.9
 			flags += -mmacosx-version-min=$(SDK_VERSION_MIN) ;
 
 		case iphone :
-			# 4.3, 5.0, 5.1, 6.0
+			# 4.3, 5.0, 5.1, 6.0 6.1 7.0
 			flags += -miphoneos-version-min=$(SDK_VERSION_MIN) ;
 
 		case iphonesimulator :
-			# 4.3, 5.0, 5.1, 6.0
+			# 4.3, 5.0, 5.1, 6.0 6.1 7.0
 			flags += -mios-simulator-version-min=$(SDK_VERSION_MIN) ;
 
 		case ipadsimulator :
-			# 4.3, 5.0, 5.1, 6.0
+			# 4.3, 5.0, 5.1, 6.0 6.1 7.0
 			flags += -mios-simulator-version-min=$(SDK_VERSION_MIN) ;
 
 		case ipad :
-			# 4.3, 5.0, 5.1, 6.0
+			# 4.3, 5.0, 5.1, 6.0 6.1 7.0
 			flags += -miphoneos-version-min=$(SDK_VERSION_MIN) ;
 	}
 
@@ -293,6 +293,18 @@ rule C.MinimumOSVersion TARGET : SDK_VERSION_MIN {
 	C.LinkFlags $(TARGET) : $(flags) ;
 
 	IOS_SDK_VERSION_MIN on $(C.ACTIVE_TOOLCHAIN_TARGET) = $(SDK_VERSION_MIN) ;
+
+	if $(TARGETINFO_LOCATE) {
+		if $(SDK_PLATFORM) in iphone iphonesimulator ipad ipadsimulator {
+			Contents += "Projects[ [[C.*]] ].IOS_SDK_VERSION_MIN[ [[$(PLATFORM)]] ][ [[$(CONFIG)]] ] = [[$(SDK_VERSION_MIN)]]
+
+" ;
+		} else if $(SDK_PLATFORM) in macosx {
+			Contents += "Projects[ [[C.*]] ].OSX_SDK_VERSION_MIN[ [[$(PLATFORM)]] ][ [[$(CONFIG)]] ] = [[$(SDK_VERSION_MIN)]]
+
+" ;
+		}
+	}
 }
 
 

--- a/bin/scripts/ide/xcode.lua
+++ b/bin/scripts/ide/xcode.lua
@@ -412,6 +412,33 @@ local function XcodeHelper_WriteXCBuildConfigurations(self, info, projectName)
 			table.insert(self.Contents, "\t\t\tisa = XCBuildConfiguration;\n")
 			table.insert(self.Contents, "\t\t\tbuildSettings = {\n")
 			table.insert(self.Contents, "\t\t\t\tTARGET_NAME = \"" .. (subProject.TargetName or projectName) .. "\";\n")
+
+			-- Deployment target (iOS).
+			local iosSdkVersionMin
+			if subProject.IOS_SDK_VERSION_MIN and  subProject.IOS_SDK_VERSION_MIN[platformName]  and  subProject.IOS_SDK_VERSION_MIN[platformName][configName] then
+				iosSdkVersionMin = subProject.IOS_SDK_VERSION_MIN[platformName][configName]
+			elseif Projects['C.*']  and  Projects['C.*'].IOS_SDK_VERSION_MIN  and  Projects['C.*'].IOS_SDK_VERSION_MIN[platformName]  and  Projects['C.*'].IOS_SDK_VERSION_MIN[platformName][configName] then
+				iosSdkVersionMin = Projects['C.*'].IOS_SDK_VERSION_MIN[platformName][configName]			
+		   	end
+
+			if iosSdkVersionMin then
+				table.insert(self.Contents, "\t\t\t\tIPHONEOS_DEPLOYMENT_TARGET = \"" .. iosSdkVersionMin .. "\";\n")
+				print( "IPHONEOS_DEPLOYMENT_TARGET found for " .. platformName .. " - " .. configName )
+			end
+
+			-- Deployment target (OSX).
+			local osxSdkVersionMin
+			if subProject.OSX_SDK_VERSION_MIN  and  subProject.OSX_SDK_VERSION_MIN[platformName]  and  subProject.OSX_SDK_VERSION_MIN[platformName][configName] then
+				osxSdkVersionMin = subProject.OSX_SDK_VERSION_MIN[platformName][configName]
+			elseif Projects['C.*']  and  Projects['C.*'].OSX_SDK_VERSION_MIN  and  Projects['C.*'].OSX_SDK_VERSION_MIN[platformName]  and  Projects['C.*'].OSX_SDK_VERSION_MIN[platformName][configName] then
+				osxSdkVersionMin = Projects['C.*'].OSX_SDK_VERSION_MIN[platformName][configName]			
+		   	end
+
+			if osxSdkVersionMin then
+				table.insert(self.Contents, "\t\t\t\tMACOSX_DEPLOYMENT_TARGET = \"" .. osxSdkVersionMin .. "\";\n")
+				print( "MACOSX_DEPLOYMENT_TARGET found for " .. platformName .. " - " .. configName )
+			end
+
 			table.insert(self.Contents, "\t\t\t\tPLATFORM = " .. platformName .. ";\n")
 			table.insert(self.Contents, "\t\t\t\tCONFIG = " .. configName .. ";\n")
 			if configInfo.OutputPath ~= '' then


### PR DESCRIPTION
Writes Deployment Target (minimum OS) requirements to iOS + MacOSX projects; without this Xcode defaults to the latest version and will then refuse to deploy to devices running and older OS. Tested with Xcode 5.
