### PR TITLE
With iOS7 the status bar no longer hides when told to, the fix is descri...

### DIFF
--- a/bin/modules/c-compilers/macosx.jam
+++ b/bin/modules/c-compilers/macosx.jam
@@ -401,6 +401,7 @@ rule C.BundleInfo TARGET : TYPE : VALUE {
 		case uidevicefamily :		C._BundleInfoArray UIDeviceFamily : $(VALUE) ;
 		case uiprerenderedicon :	C._BundleInfoBoolean UIPrerenderedIcon : $(VALUE) ;
 		case uistatusbarhidden :	C._BundleInfoBoolean UIStatusBarHidden : $(VALUE) ;
+		case uiviewcontrollerbasedstatusbarappearance : C._BundleInfoBoolean UIViewControllerBasedStatusBarAppearance : $(VALUE) ;
 		case uiinterfaceorientation :	
 			if $(VALUE) = portrait {
 				C._BundleInfoString UIInterfaceOrientation : UIInterfaceOrientationPortrait ;


### PR DESCRIPTION
Allows UIViewControllerBasedStatusBarAppearance to be set, which fixes status bar not hiding as described in http://stackoverflow.com/questions/18059703/cannot-hide-status-bar-in-ios7
