### PR TITLE
Add final configurations; same as releaseltcg but define _FINAL.

### DIFF
--- a/bin/modules/c-compilers/configs/_mingw-win32-final.jam
+++ b/bin/modules/c-compilers/configs/_mingw-win32-final.jam
@@ -1,0 +1,7 @@
+C.ToolchainHelper mingw ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/_vc-win32-final.jam
+++ b/bin/modules/c-compilers/configs/_vc-win32-final.jam
@@ -1,0 +1,14 @@
+C.CFlags * : /O2 /Oi /EHsc /Gy /MD /W3 /Z7 ;
+C.C++Flags * : /O2 /Oi /EHsc /Gy /MD /W3 /Z7 ;
+C.LinkFlags * : /INCREMENTAL:NO /DEBUG /MACHINE:X86 /OPT:REF /OPT:ICF ;
+
+C.Defines * : WIN32 _WINDOWS _FINAL ;
+
+if $(C.COMPILER) != vc6 {
+	C.CFlags * : /GL ;
+	C.C++Flags * : /GL ;
+	C.LibFlags * : /LTCG ;
+	C.LinkFlags * : /LTCG ;
+}
+
+C.ToolchainHelper Global_RELEASE ;

--- a/bin/modules/c-compilers/configs/_vc-win64-final.jam
+++ b/bin/modules/c-compilers/configs/_vc-win64-final.jam
@@ -1,0 +1,12 @@
+C.CFlags * : /O2 /Oi /EHsc /Gy /MD /W3 /Z7 ;
+C.C++Flags * : /O2 /Oi /EHsc /Gy /MD /W3 /Z7 ;
+C.LinkFlags * : /INCREMENTAL:NO /DEBUG /MACHINE:X64 /OPT:REF /OPT:ICF ;
+
+C.Defines * : _WIN64 _AMD64_ _WINDOWS _FINAL ;
+
+C.CFlags * : /GL ;
+C.C++Flags * : /GL ;
+C.LibFlags * : /LTCG ;
+C.LinkFlags * : /LTCG ;
+
+C.ToolchainHelper Global_RELEASE ;

--- a/bin/modules/c-compilers/configs/ipad-final.jam
+++ b/bin/modules/c-compilers/configs/ipad-final.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/ipadsimulator-final.jam
+++ b/bin/modules/c-compilers/configs/ipadsimulator-final.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios-simulator Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/iphone-final.jam
+++ b/bin/modules/c-compilers/configs/iphone-final.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/iphonesimulator-final.jam
+++ b/bin/modules/c-compilers/configs/iphonesimulator-final.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios-simulator Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/linux32-final.jam
+++ b/bin/modules/c-compilers/configs/linux32-final.jam
@@ -1,0 +1,10 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper linux-gcc Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m32 ;
+C.Flags * : C++	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m32 ;
+C.Flags * : M	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m32 ;
+C.Flags * : MM	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m32 ;
+C.LinkFlags * : -m32 ;
+

--- a/bin/modules/c-compilers/configs/linux64-final.jam
+++ b/bin/modules/c-compilers/configs/linux64-final.jam
@@ -1,0 +1,10 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper linux-gcc Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m64 ;
+C.Flags * : C++	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m64 ;
+C.Flags * : M	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m64 ;
+C.Flags * : MM	: -g -O3 -fomit-frame-pointer -fstrength-reduce -m64 ;
+C.LinkFlags * : -m64 ;
+

--- a/bin/modules/c-compilers/configs/macosx32-final.jam
+++ b/bin/modules/c-compilers/configs/macosx32-final.jam
@@ -1,0 +1,12 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper macosx ;
+C.ToolchainHelper Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : C++	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : M	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : MM	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.LibFlags * : -arch_only i386 ;
+C.LinkFlags * : -arch i386 ;
+

--- a/bin/modules/c-compilers/configs/macosx64-final.jam
+++ b/bin/modules/c-compilers/configs/macosx64-final.jam
@@ -1,0 +1,12 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper macosx ;
+C.ToolchainHelper Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch x86_64 ;
+C.Flags * : C++	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch x86_64 ;
+C.Flags * : M	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch x86_64 ;
+C.Flags * : MM	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch x86_64 ;
+C.LibFlags * : -arch_only x86_64 ;
+C.LinkFlags * : -arch x86_64 ;
+

--- a/bin/modules/c-compilers/configs/mingw-win32-final.jam
+++ b/bin/modules/c-compilers/configs/mingw-win32-final.jam
@@ -1,0 +1,2 @@
+C.ToolchainSpecKeys C.COMPILER C.PLATFORM C.CONFIG ;
+C.ToolchainHelper win32 ;

--- a/bin/modules/c-compilers/configs/win32-final.jam
+++ b/bin/modules/c-compilers/configs/win32-final.jam
@@ -1,0 +1,3 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper win32 ;
+

--- a/bin/modules/c-compilers/configs/win64-final.jam
+++ b/bin/modules/c-compilers/configs/win64-final.jam
@@ -1,0 +1,3 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper win64 ;
+

--- a/bin/modules/c-compilers/configs/xbox360-final.jam
+++ b/bin/modules/c-compilers/configs/xbox360-final.jam
@@ -1,0 +1,9 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+IncludeModule c-compilers/xbox360-autodetect ;
+
+C.CFlags *		: /O2 /Oi /EHsc /Gy /MT /W3 /Z7 /GL ;
+C.C++Flags * 	: /O2 /Oi /EHsc /Gy /MT /W3 /Z7 /GL ;
+C.LibFlags *	: /LTCG ;
+C.LinkFlags *	: /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF /LTCG ;
+
+C.Defines * : _XBOX _FINAL ;


### PR DESCRIPTION
All the companies I have worked at have required a final configuration. The typical set up I have encountered is along the lines of:

debug : _DEBUG defined, no optimizations
release : NDEBUG defined, optimizations
final : NDEBUG _FINAL defined, optimizations

On top of this; for iOS/OSX builds, typically additional configurations are used:

adhoc : NDEBUG _FINAL defined, optimizations
distribution : NDEBUG _FINAL _DISTRIBUTION defined, optimizations

Although AdHoc looks the same as Final (on the face of it) it will be using different code signing identify and provisioning profile.

As I am not sure whether you will wish to take these changes main line or not, I am splitting the final and adhoc/distribution into two separate pull requests. From my point of view I'd like you to take them all, but if you felt one or the other were acceptable that would also be beneficial I imagine.
