### PR TITLE
AdHoc/Distribution configurations for iOS/OSX.

### DIFF
--- a/bin/modules/c-compilers/configs/ipad-adhoc.jam
+++ b/bin/modules/c-compilers/configs/ipad-adhoc.jam
@@ -1,0 +1,9 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;
+C.SetTaskAllow * : false ;

--- a/bin/modules/c-compilers/configs/ipad-distribution.jam
+++ b/bin/modules/c-compilers/configs/ipad-distribution.jam
@@ -1,0 +1,9 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios Global_RELEASE ;
+
+C.Defines * : _FINAL _DISTRIBUTION ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;
+C.SetTaskAllow * : false ;

--- a/bin/modules/c-compilers/configs/ipadsimulator-adhoc.jam
+++ b/bin/modules/c-compilers/configs/ipadsimulator-adhoc.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios-simulator Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/ipadsimulator-distribution.jam
+++ b/bin/modules/c-compilers/configs/ipadsimulator-distribution.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios-simulator Global_RELEASE ;
+
+C.Defines * : _FINAL _DISTRIBUTION ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/iphone-adhoc.jam
+++ b/bin/modules/c-compilers/configs/iphone-adhoc.jam
@@ -1,0 +1,9 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;
+C.SetTaskAllow * : false ;

--- a/bin/modules/c-compilers/configs/iphone-distribution.jam
+++ b/bin/modules/c-compilers/configs/iphone-distribution.jam
@@ -1,0 +1,9 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios Global_RELEASE ;
+
+C.Defines * : _FINAL _DISTRIBUTION ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;
+C.SetTaskAllow * : false ;

--- a/bin/modules/c-compilers/configs/iphonesimulator-adhoc.jam
+++ b/bin/modules/c-compilers/configs/iphonesimulator-adhoc.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios-simulator Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/iphonesimulator-distribution.jam
+++ b/bin/modules/c-compilers/configs/iphonesimulator-distribution.jam
@@ -1,0 +1,8 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper ios-simulator Global_RELEASE ;
+
+C.Defines * : _FINAL _DISTRIBUTION ;
+C.Flags * : CC	: -g -O3 ;
+C.Flags * : C++	: -g -O3 ;
+C.Flags * : M	: -g -O3 ;
+C.Flags * : MM	: -g -O3 ;

--- a/bin/modules/c-compilers/configs/macosx32-adhoc.jam
+++ b/bin/modules/c-compilers/configs/macosx32-adhoc.jam
@@ -1,0 +1,12 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper macosx ;
+C.ToolchainHelper Global_RELEASE ;
+
+C.Defines * : _FINAL ;
+C.Flags * : CC	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : C++	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : M	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : MM	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.LibFlags * : -arch_only i386 ;
+C.LinkFlags * : -arch i386 ;
+

--- a/bin/modules/c-compilers/configs/macosx32-distribution.jam
+++ b/bin/modules/c-compilers/configs/macosx32-distribution.jam
@@ -1,0 +1,12 @@
+C.ToolchainSpecKeys C.PLATFORM C.CONFIG ;
+C.ToolchainHelper macosx ;
+C.ToolchainHelper Global_RELEASE ;
+
+C.Defines * : _FINAL _DISTRIBUTION ;
+C.Flags * : CC	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : C++	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : M	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.Flags * : MM	: -g -O3 -fomit-frame-pointer -fstrength-reduce -arch i386 ;
+C.LibFlags * : -arch_only i386 ;
+C.LinkFlags * : -arch i386 ;
+


### PR DESCRIPTION
AdHoc/Distribution configurations for iOS/OSX. Note they are based on the final/releaseltcg configurations. For iOS, task allow is set to false (this is a requirement), and in distribution _DISTRIBUTION is defined, this is required as some code (tracking UDIDs, speaking to correct server) needs to know whether it is an AdHoc or Distribution build.
