### PR TITLE
Current ASM building (.s files) is done via the C.CC rule; however Clang...

### DIFF
--- a/bin/modules/c-compilers/configs/_clang.jam
+++ b/bin/modules/c-compilers/configs/_clang.jam
@@ -24,7 +24,8 @@
 
 	STDHDRS on $(C.COMPILER_SUITE_SYMBOL) = /usr/include ;
 
-	C.Flags * : CC	: -x c -Wno-unused-parameter ;
+	# Removed '-x c' as it break ASM compiles.
+	C.Flags * : CC	: -Wno-unused-parameter ;
 	C.Flags * : C++	: -x c++ -Wno-unused-parameter ;
 	C.Flags * : M	: -x objective-c -Wno-unused-parameter ;
 	C.Flags * : MM	: -x objective-c++ -Wno-unused-parameter ;


### PR DESCRIPTION
Fixes ASM (.s) file building under Clang.

Issue reported here : http://jamplus.org/boards/1/topics/474?r=535 which compiles under iOS/arm7/Clang with a sample .s file that can be used for testing. See commit message for more information about this.
