### PR TITLE
Specify armv7 (not armv7s) as architecture for iPhone builds. Only iPhon...

### DIFF
--- a/bin/modules/c-compilers/macosx.jam
+++ b/bin/modules/c-compilers/macosx.jam
@@ -101,13 +101,13 @@ rule C.MacOSX_SDK SDK_VERSION {
 					developerRoot = [ Match ([^$(NEWLINE)]*) : [ Shell "xcode-select -p" ] ] ;
 					isysroot = $(developerRoot)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk ;
 					sdkroot = iphoneos6.1 ;
-					flags += -arch armv7s ;
+					flags += -arch armv7 ;
 
 				case 7.0 :
 					developerRoot = [ Match ([^$(NEWLINE)]*) : [ Shell "xcode-select -p" ] ] ;
 					isysroot = $(developerRoot)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk ;
 					sdkroot = iphoneos7.0 ;
-					flags += -arch armv7s ;
+					flags += -arch armv7 ;
 
 				case * :		Exit "* MacOSX_SDK: Unsupported version $(SDK_VERSION) for SDK platform $(SDK_PLATFORM)." ;
 			}


### PR DESCRIPTION
Use armv7 not armv7s for iPhone builds.

Armv7s is not supported on devices older than iPhone5 (yet older devices can run iOS 6/7). Without this change it is not possible to submit builds to the AppStore to run on anything except iPhone5.

Ultimately it would be nice to package up .app's with multiple binaries in, that way we could have armv7 and armv7s in one package. I guess with this new tool chain stuff in nextgen this maybe possible?
