### PR TITLE
Fixes Xcode workspace generation failure

### DIFF
--- a/bin/scripts/ide/xcode.lua
+++ b/bin/scripts/ide/xcode.lua
@@ -178,16 +178,16 @@ local function XcodeHelper_GetProjectExportInfo(projectName)
 				project.ConfigInfo[platformName][configName] = configInfo
 			end
 
-			if configInfo.Defines == ''  and  project.Defines then
+			if configInfo.Defines == ''  and  project.Defines  and  project.Defines[platformName]  and  project.Defines[platformName][configName] then
 				configInfo.Defines = table.concat(project.Defines[platformName][configName], ';'):gsub('"', '\\&quot;')
 			end
-			if configInfo.IncludePaths == ''  and  project.IncludePaths then
+			if configInfo.IncludePaths == ''  and  project.IncludePaths  and project.IncludePaths[platformName]  and  project.IncludePaths[platformName][configName]  then
 				configInfo.Includes = table.concat(project.IncludePaths[platformName][configName], ';')
 			end
-			if configInfo.OutputPath == ''  and  project.OutputPaths then
+			if configInfo.OutputPath == ''  and  project.OutputPaths  and project.OutputPaths[platformName]  and  project.OutputPaths[platformName][configName]  then
 				configInfo.OutputPath = project.OutputPaths[platformName][configName]
 			end
-			if configInfo.OutputName == ''  and  project.OutputNames then
+			if configInfo.OutputName == ''  and  project.OutputNames  and project.OutputNames[platformName]  and project.OutputNames[platformName][configName]  then
 				configInfo.OutputName = project.OutputNames[platformName][configName]
 			end
 		end


### PR DESCRIPTION
Fixes this error:

---
## -- ...bin/scripts/ide/xcode.lua:182: attempt to index field '?' (a nil value):

stack traceback:
    ...usNextGen/bin/macosx32/../scripts/JamToWorkspace.lua:121: in function <...usNextGen/bin/macosx32/../scripts/JamToWorkspace.lua:97>
    .../bin/scripts/ide/xcode.lua:182: in function 'XcodeHelper_GetProjectExportInfo'
    .../bin/scripts/ide/xcode.lua:582: in function 'Write'
    .../bin/macosx32/../scripts/JamToWorkspace.lua:554: in function 'DumpProject'
    .../bin/macosx32/../scripts/JamToWorkspace.lua:664: in function 'DumpWorkspace'
    .../bin/macosx32/../scripts/JamToWorkspace.lua:988: in function <.../bin/macosx32/../scripts/JamToWorkspace.lua:702>
    [C]: in function 'xpcall'
    .../bin/macosx32/../scripts/JamToWorkspace.lua:1066: in main chunk
##     [C]: ?

More information available in commit message.
