### PR TITLE
Defer adding contents to plist file on C.BundleInfo call

### DIFF
--- a/bin/modules/c-compilers/macosx.jam
+++ b/bin/modules/c-compilers/macosx.jam
@@ -328,40 +328,54 @@ rule C.MinimumOSVersion TARGET : SDK_VERSION_MIN {
 	}
 }
 
+rule C._InfoPlistKeyExists KEY
+{
+	on $(C.ACTIVE_TOOLCHAIN_TARGET)
+	{
+		if $(INFO_PLIST_KEYS)
+		{
+			for _key in $(INFO_PLIST_KEYS)
+			{
+				if $(_key) = $(KEY)
+				{
+					return true ;
+				}
+			}
+		}
+	}
+	return false ;
+}
 
 rule C._BundleInfoArray KEY : VALUE {
-	INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) += "$(TAB)<key>$(KEY)</key>$(NEWLINE)$(TAB)<array>$(NEWLINE)" ;
-	for value in $(VALUE) {
-		INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) += "$(TAB)$(TAB)<string>$(value)</string>$(NEWLINE)" ;
+	if [ C._InfoPlistKeyExists $(KEY) ] = false {
+		INFO_PLIST_KEYS on $(C.ACTIVE_TOOLCHAIN_TARGET) += $(KEY) ;
 	}
-	INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) += "$(TAB)</array>$(NEWLINE)" ;
+	INFO_PLIST_KEYS.$(KEY).TYPE on $(C.ACTIVE_TOOLCHAIN_TARGET) = Array ;
+	INFO_PLIST_KEYS.$(KEY).VALUE on $(C.ACTIVE_TOOLCHAIN_TARGET) = $(VALUE) ;
 }
 
 
 rule C._BundleInfoBoolean KEY : VALUE {
-	INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) += "$(TAB)<key>$(KEY)</key>$(NEWLINE)$(TAB)" ;
-	if $(VALUE) = true {
-		INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) += "<true/>$(NEWLINE)" ;
-	} else {
-		INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) += "<false/>$(NEWLINE)" ;
+	if [ C._InfoPlistKeyExists $(KEY) ] = false {
+		INFO_PLIST_KEYS on $(C.ACTIVE_TOOLCHAIN_TARGET) += $(KEY) ;
 	}
+	INFO_PLIST_KEYS.$(KEY).TYPE on $(C.ACTIVE_TOOLCHAIN_TARGET) = Boolean ;
+	INFO_PLIST_KEYS.$(KEY).VALUE on $(C.ACTIVE_TOOLCHAIN_TARGET) = $(VALUE) ;
 }
 
 
 rule C._BundleInfoString KEY : VALUE {
-	INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) += "$(TAB)<key>$(KEY)</key>$(NEWLINE)$(TAB)<string>$(VALUE)</string>$(NEWLINE)" ;
+	if [ C._InfoPlistKeyExists $(KEY) ] = false {
+		INFO_PLIST_KEYS on $(C.ACTIVE_TOOLCHAIN_TARGET) += $(KEY) ;
+	}
+	INFO_PLIST_KEYS.$(KEY).TYPE on $(C.ACTIVE_TOOLCHAIN_TARGET) = String ;
+	INFO_PLIST_KEYS.$(KEY).VALUE on $(C.ACTIVE_TOOLCHAIN_TARGET) = $(VALUE) ;
 }
 
 
 rule C.BundleInfo TARGET : TYPE : VALUE {
 	TARGET = [ ActiveTarget $(TARGET) ] ;
-	on $(C.ACTIVE_TOOLCHAIN_TARGET) if ! $(INFO_PLIST) {
-		INFO_PLIST on $(C.ACTIVE_TOOLCHAIN_TARGET) ?= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-<plist version=\"1.0\">
-<dict>
-" ;
-
+	on $(C.ACTIVE_TOOLCHAIN_TARGET) if ! $(INFO_PLIST_KEYS) {
 		C._BundleInfoString CFBundleDevelopmentRegion : en ;
 		C._BundleInfoString CFBundleExecutable : [ C._retrieveOutputName $(TARGET) ] ;
 		C._BundleInfoString CFBundleInfoDictionaryVersion : 6.0 ;
@@ -552,8 +566,38 @@ rule C.macosx._ApplicationFromObjects_PostBuild {
 		Depends $(bundleTarget) : $(pkginfo) ;
 		Clean $(cleanBundleTarget) : $(pkginfo) ;
 
-		local infoplistcontents = $(INFO_PLIST:Z=$(C.ACTIVE_TOOLCHAIN_TARGET)) ;
-		if $(infoplistcontents) {
+		if $(INFO_PLIST_KEYS:Z=$(C.ACTIVE_TOOLCHAIN_TARGET)) {
+
+			# Set up Info.plist file header.
+			local infoplistcontents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+" ;
+			# Set up each key/value pair based on the type (Array/Boolean/String).
+			for _key in $(INFO_PLIST_KEYS:Z=$(C.ACTIVE_TOOLCHAIN_TARGET))
+			{
+				switch $(INFO_PLIST_KEYS.$(_key).TYPE:Z=$(C.ACTIVE_TOOLCHAIN_TARGET))
+				{
+					case Array :
+						infoplistcontents += "$(TAB)<key>$(_key)</key>$(NEWLINE)$(TAB)<array>$(NEWLINE)" ;
+						for value in $(INFO_PLIST_KEYS.$(_key).VALUE:Z=$(C.ACTIVE_TOOLCHAIN_TARGET)) {
+							infoplistcontents += "$(TAB)$(TAB)<string>$(value)</string>$(NEWLINE)" ;
+						}
+						infoplistcontents += "$(TAB)</array>$(NEWLINE)" ;
+					case Boolean :
+						infoplistcontents += "$(TAB)<key>$(_key)</key>$(NEWLINE)$(TAB)" ;
+						if $(INFO_PLIST_KEYS.$(_key).VALUE:Z=$(C.ACTIVE_TOOLCHAIN_TARGET)) = true {
+							infoplistcontents += "<true/>$(NEWLINE)" ;
+						} else {
+							infoplistcontents += "<false/>$(NEWLINE)" ;
+						}
+					case String :
+						infoplistcontents += "$(TAB)<key>$(_key)</key>$(NEWLINE)$(TAB)<string>$(INFO_PLIST_KEYS.$(_key).VALUE:Z=$(C.ACTIVE_TOOLCHAIN_TARGET))</string>$(NEWLINE)" ;
+				}
+			}
+
+			# Set up Info.plist file footer.
 			infoplistcontents += "</dict>
 </plist>
 " ;
@@ -563,7 +607,7 @@ rule C.macosx._ApplicationFromObjects_PostBuild {
 			MakeLocate $(infoplist) : $(bundlePath) ;
 			CONTENTS on $(infoplist) = $(infoplistcontents) ;
 			WriteFile $(infoplist) ;
-			
+
 			UseCommandLine $(infoplist) : $(infoplistcontents) ;
 			Depends $(bundleTarget) : $(infoplist) ;
 			Clean $(cleanBundleTarget) : $(infoplist) ;


### PR DESCRIPTION
I want to make universal apps; to do this I need UIDeviceFamily to have the array contents 1, 2. If I add:

C.BundleInfo Target : uidevicefamily : 1 2 ; 

To my Jamfile, the generated Info.plist has this entry, but higher up in the file it also has UIDeviceFamily set to 1, this is because this gets set by default in macosx.jam - the behaviour of setting this by default is good, as it means the user doesn't have to specify loads of standard Info.plist keys, however the behaviour we want is for the user supplied key/values to override the defaults. This is exactly what this pull request does, instead of building up the Info.plist contents during the C.BundleInfo call, we now just store the key/value/type for each C.BundleInfo call, and then just before writing out the Info.plist we iterate the stored data and write out each key/value - if the same key is specified twice (like in my uidevicefamily case) the second (last) call will take priority.

I have tested this and am now able to make universal apps.

Please let me know if this pull request is a mess; I accidentally created my feature branch from my development branch which was full of other changes; so I had to then rebase my branch, cherry pick the commit, and commit, push and create this pull request. Worse case you really just need to merge/consider this one commit: https://github.com/Scraft/jamplus/commit/27efe664cff61a464a9630a9ea92d068189fc7c7
