### PR TITLE
Fix IPHONE_SDK_VERSION and IOS_SDKVERSION_MIN not being set

### DIFF
--- a/bin/modules/c-compilers/macosx.jam
+++ b/bin/modules/c-compilers/macosx.jam
@@ -375,6 +375,9 @@ rule C._BundleInfoString KEY : VALUE {
 
 rule C.BundleInfo TARGET : TYPE : VALUE {
 	TARGET = [ ActiveTarget $(TARGET) ] ;
+	IPHONEOS_SDK_VERSION = $(IPHONEOS_SDK_VERSION:Z=$(C.ACTIVE_TOOLCHAIN_*)) ;
+	IOS_SDK_VERSION_MIN = $(IOS_SDK_VERSION_MIN:Z=$(C.ACTIVE_TOOLCHAIN_*)) ;
+
 	on $(C.ACTIVE_TOOLCHAIN_TARGET) if ! $(INFO_PLIST_KEYS) {
 		C._BundleInfoString CFBundleDevelopmentRegion : en ;
 		C._BundleInfoString CFBundleExecutable : [ C._retrieveOutputName $(TARGET) ] ;


### PR DESCRIPTION
IPHONE_SDK_VERSION and IOS_SDKVERSION_MIN were not available therefore these entries weren't being written out into the Info.plist which meant the build was failing to upload.

NOTE : This pull request is built on top of #29 so please take #29 first.
