### PR TITLE
Fix bundle path not being available when building fat binary.

### DIFF
--- a/bin/modules/c/toolchain/clang/ios-shared.jam
+++ b/bin/modules/c/toolchain/clang/ios-shared.jam
@@ -392,6 +392,15 @@ actions C.ios._GenerateDSYMFile {
 rule C.ios.GenerateDSYMFile TARGET {
 	TARGET = [ ActiveTarget $(TARGET) ] ;
 	local bundlePath = $(BUNDLE_PATH:Z=$(C.ACTIVE_TOOLCHAIN_TARGET)) ;
+    
+    # When making a fat binary (with multiple architectures), bundle path is not set.
+    if ! $(bundlePath)
+    {
+        local outputName = [ C._retrieveOutputName ] ;
+        local outputPath = [ C._retrieveOutputPath ] ;
+        bundlePath = $(outputPath)/$(outputName).app ;
+    }
+
 	local dsymBundlePath = $(bundlePath).dSYM ;
 	local _t = $(LIPO_TARGET:Z=$(C.ACTIVE_TOOLCHAIN_TARGET)) ;
 	local _t.dsym = $(_t).DSYM ;


### PR DESCRIPTION
I tried building the ios/simple-multiple-architectures sample but it failed as the DSYM generation stage didn't have a OUTPUT_PATH set, which was because a BUNDLE_PATH was not set (it is set separately for each architecture, but not for the 'global' architecture, used for the output from the lipo stage). Ultimately I believe there will be more knock ons from not having BUNDLE_PATH available (where do I copy assets to when making the bundle) which I'll have a look at next (which possibly will make this pull request invalid but I'm making it anyway to encourage any feedback on the correct way to work with jamplus3 branch).