### PR TITLE
Fix Windows library scanner to support files larger than 2GB

### DIFF
--- a/src/filent.c
+++ b/src/filent.c
@@ -256,7 +256,7 @@ file_archscan(
 	struct ar_hdr ar_hdr;
 	char *string_table = 0;
 	char buf[ MAXJPATH ];
-	long offset;
+	__int64 offset;
 	int fd;
 
 	if( ( fd = open( archive, O_RDONLY | O_BINARY, 0 ) ) < 0 )
@@ -348,7 +348,7 @@ file_archscan(
 #endif
 
 	    offset += SARHDR + lar_size;
-	    lseek( fd, offset, 0 );
+	    _lseeki64( fd, offset, 0 );
 	}
 
 #ifdef OPT_FIX_NT_ARSCAN_LEAK


### PR DESCRIPTION
If a Windows archive (.lib) file exceeds 2GB then the jam archive scanner triggers an internal overflow. As a result all files in the archive with an offset larger than 2GB are skipped and the corresponding callback is never executed.

This leads to jam compiling those files with each invocation because it falsely assumes the files are not part of the archive.